### PR TITLE
Locate image by contract and token id

### DIFF
--- a/Images-Core/src/main/java/com/andavin/images/Images.java
+++ b/Images-Core/src/main/java/com/andavin/images/Images.java
@@ -30,6 +30,7 @@ import com.andavin.images.data.FileDataManager;
 import com.andavin.images.data.MySQLDataManager;
 import com.andavin.images.data.SQLiteDataManager;
 import com.andavin.images.image.CustomImage;
+import com.andavin.images.image.CustomImageSection;
 import com.andavin.images.listener.ClickImageListener;
 import com.andavin.reflect.exception.UncheckedClassNotFoundException;
 import com.andavin.util.LocationUtil;
@@ -202,10 +203,21 @@ public class Images extends JavaPlugin implements Listener {
             addImage(toImage(Base64.getDecoder().decode(data)));
         });
 
-        MultiLib.onString(this, "images:deleteimage", data -> {
-            CustomImage image = toImage(Base64.getDecoder().decode(data));
-            removeImage(image);
-            image.destroy();
+        MultiLib.onString(this, "images:deleteimage", string -> {
+            String[] args = string.split("\t");
+            String contract = args[0];
+            int tokenId = Integer.parseInt(args[1]);
+            Scheduler.async(() -> {
+                synchronized (IMAGES) {
+                    for (CustomImage image : IMAGES) {
+                        if (contract.equals(image.getContract()) && tokenId == image.getTokenId()) {
+                            removeImage(image);
+                            image.destroy();
+                            return;
+                        }
+                    }
+                }
+            });
         });
 
         Bukkit.getPluginManager().registerEvents(new ClickImageListener(), this);

--- a/Images-Core/src/main/java/com/andavin/images/command/CreateCommand.java
+++ b/Images-Core/src/main/java/com/andavin/images/command/CreateCommand.java
@@ -292,7 +292,7 @@ final class CreateCommand extends BaseCommand implements Listener {
             if (response.statusCode() == 200) {
                 if (Images.removeImage(image)) {
                     image.destroy();
-                    MultiLib.notify("images:deleteimage", Base64.getEncoder().encodeToString(toByteArray(image)));
+                    MultiLib.notify("images:deleteimage", image.getContract() + "\t" + image.getTokenId());
                     caller.sendMessage("§aNFT successfully deleted, you can now create token " + task.tokenId);
                 } else
                     caller.sendMessage("§cFailed to delete NFT");

--- a/Images-Core/src/main/java/com/andavin/images/command/DeleteCommand.java
+++ b/Images-Core/src/main/java/com/andavin/images/command/DeleteCommand.java
@@ -128,7 +128,7 @@ final class DeleteCommand extends BaseCommand implements Listener {
                         if (response.statusCode() == 200) {
                             if (Images.removeImage(image)) {
                                 image.destroy();
-                                MultiLib.notify("images:deleteimage", Base64.getEncoder().encodeToString(toByteArray(image)));
+                                MultiLib.notify("images:deleteimage", image.getContract() + "\t" + image.getTokenId());
                                 player.sendMessage("§aNFT successfully deleted");
                             } else
                                 player.sendMessage("§cFailed to delete NFT");


### PR DESCRIPTION
Syncing an image deletion by copying the image Object to another
server is not guaranteed to work as the images may have different
entity ids on each server, meaning the deletion won't be correctly
sent to the Minecraft client. Instead, locate the server's Object
for that image using the unique contract and token id.