### PR TITLE
refactor: token id's are now BigIntegers 

### DIFF
--- a/Images-Common/pom.xml
+++ b/Images-Common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Common/src/main/java/com/andavin/images/image/CustomImage.java
+++ b/Images-Common/src/main/java/com/andavin/images/image/CustomImage.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.util.*;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -60,25 +61,38 @@ public class CustomImage implements Serializable {
     private final UUID creator;
     private final UUID uuid;
     private final String contract;
-    private final int tokenId;
+    @Deprecated
+    private int tokenId;
+    private BigInteger newTokenId;
     private final String imageName;
     private final BlockFace direction;
     private final Map<Integer, CustomImageSection> sections = new HashMap<>();
 
-    public CustomImage(String imageName, String contract, int tokenId, Location location, BlockFace direction, BufferedImage image) {
-        this(UNKNOWN_CREATOR, contract, tokenId, imageName, location, direction, image);
+    public CustomImage(String imageName, String contract, int tokenId, BigInteger newTokenId, Location location, BlockFace direction, BufferedImage image) {
+        this(UNKNOWN_CREATOR, contract, tokenId, newTokenId, imageName, location, direction, image);
     }
 
-    public CustomImage(UUID creator, String contract, int tokenId, String imageName, Location location,
+    public CustomImage(UUID creator, String contract, int tokenId, BigInteger newTokenId, String imageName, Location location,
                        BlockFace direction, BufferedImage image) {
         this.contract = contract;
         this.tokenId = tokenId;
+        this.newTokenId = newTokenId;
         this.imageName = imageName;
         this.direction = direction;
         this.location = location;
         this.creator = creator;
         this.uuid = UUID.randomUUID();
         this.update(image);
+
+    }
+
+    public boolean updateTokenId() {
+        if(tokenId != -1) {
+            newTokenId = BigInteger.valueOf(tokenId);
+            tokenId = -1;
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -120,8 +134,8 @@ public class CustomImage implements Serializable {
         return contract;
     }
 
-    public int getTokenId() {
-        return tokenId;
+    public BigInteger getTokenId() {
+        return newTokenId;
     }
 
     public Location getLocation() {

--- a/Images-Common/src/main/java/com/andavin/images/image/CustomImage.java
+++ b/Images-Common/src/main/java/com/andavin/images/image/CustomImage.java
@@ -68,14 +68,14 @@ public class CustomImage implements Serializable {
     private final BlockFace direction;
     private final Map<Integer, CustomImageSection> sections = new HashMap<>();
 
-    public CustomImage(String imageName, String contract, int tokenId, BigInteger newTokenId, Location location, BlockFace direction, BufferedImage image) {
-        this(UNKNOWN_CREATOR, contract, tokenId, newTokenId, imageName, location, direction, image);
+    public CustomImage(String imageName, String contract, BigInteger newTokenId, Location location, BlockFace direction, BufferedImage image) {
+        this(UNKNOWN_CREATOR, contract, newTokenId, imageName, location, direction, image);
     }
 
-    public CustomImage(UUID creator, String contract, int tokenId, BigInteger newTokenId, String imageName, Location location,
+    public CustomImage(UUID creator, String contract, BigInteger newTokenId, String imageName, Location location,
                        BlockFace direction, BufferedImage image) {
         this.contract = contract;
-        this.tokenId = tokenId;
+        this.tokenId = -1;
         this.newTokenId = newTokenId;
         this.imageName = imageName;
         this.direction = direction;

--- a/Images-Core/pom.xml
+++ b/Images-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-Core/src/main/java/com/andavin/images/Images.java
+++ b/Images-Core/src/main/java/com/andavin/images/Images.java
@@ -51,6 +51,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.*;
+import java.math.BigInteger;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
@@ -207,16 +208,12 @@ public class Images extends JavaPlugin implements Listener {
         MultiLib.onString(this, "images:deleteimage", string -> {
             String[] args = string.split("\t");
             String contract = args[0];
-            int tokenId = Integer.parseInt(args[1]);
+            BigInteger tokenId = new BigInteger(args[1]);
             Scheduler.async(() -> {
-                synchronized (IMAGES) {
-                    for (CustomImage image : IMAGES) {
-                        if (contract.equals(image.getContract()) && tokenId == image.getTokenId()) {
-                            removeImage(image);
-                            image.destroy();
-                            return;
-                        }
-                    }
+                CustomImage image = getImage(contract, tokenId);
+                if(image != null) {
+                    removeImage(image);
+                    image.destroy();
                 }
             });
         });
@@ -428,8 +425,12 @@ public class Images extends JavaPlugin implements Listener {
     }
 
     public static void removeListenerTaskAlawys(Player player) {
-        if(LISTENER_TASKS_ALWAYS.containsKey(player.getUniqueId()))
+        if (LISTENER_TASKS_ALWAYS.containsKey(player.getUniqueId()))
             LISTENER_TASKS_ALWAYS.remove(LISTENER_TASKS_ALWAYS.get(player.getUniqueId()));
+    }
+
+    public static void save(CustomImage image) {
+        dataManager.save(image);
     }
 
     /**
@@ -495,14 +496,14 @@ public class Images extends JavaPlugin implements Listener {
         }
     }
 
-    public static CustomImage getImage(String contract, int tokenId) {
+    public static CustomImage getImage(String contract, BigInteger tokenId) {
         CustomImage[] images;
         synchronized (IMAGES) {
             images = IMAGES.toArray(EMPTY_IMAGES_ARRAY);
         }
 
         for (CustomImage image : images) {
-            if(image.getContract() != null && image.getContract().equals(contract) && image.getTokenId() == tokenId) {
+            if(image.getContract() != null && image.getContract().equals(contract) && image.getTokenId().equals(tokenId)) {
                 return image;
             }
         }

--- a/Images-Core/src/main/java/com/andavin/images/command/CreateCommand.java
+++ b/Images-Core/src/main/java/com/andavin/images/command/CreateCommand.java
@@ -57,6 +57,7 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.*;
+import java.math.BigInteger;
 import java.net.URI;
 import java.util.*;
 import java.util.List;
@@ -119,9 +120,9 @@ final class CreateCommand extends BaseCommand implements Listener {
         ImageSupplier imageSupplier;
         Supplier<String> nameSupplier;
         String address = args[0];
-        int tokenId;
+        BigInteger tokenId;
         try {
-            tokenId = Integer.parseInt(args[1]);
+            tokenId = new BigInteger(args[1]);
         } catch (NumberFormatException e) {
             player.sendMessage(ChatColor.RED + "Token ID must be a number!");
             return;
@@ -271,7 +272,7 @@ final class CreateCommand extends BaseCommand implements Listener {
                     }
                     player.sendMessage(ChatColor.YELLOW + "Attempting to mint NFT..");
 
-                    CustomImage customImage = new CustomImage(player.getUniqueId(), task.contract, task.tokenId,
+                    CustomImage customImage = new CustomImage(player.getUniqueId(), task.contract, -1, task.tokenId,
                             task.nameSupplier.get(), location, direction, image);
 
                     for (CustomImageSection section : customImage.getSections()) {
@@ -369,9 +370,9 @@ final class CreateCommand extends BaseCommand implements Listener {
         private final ImageSupplier imageSupplier;
         private final Supplier<String> nameSupplier;
         private final String contract;
-        private final int tokenId;
+        private final BigInteger tokenId;
 
-        CreateImageTask(double scale, ImageSupplier supplier, Supplier<String> nameSupplier, String contract, int tokenId) {
+        CreateImageTask(double scale, ImageSupplier supplier, Supplier<String> nameSupplier, String contract, BigInteger tokenId) {
             checkArgument(scale > 0,
                     "§cScale must be greater than zero§f %s", scale);
             this.scale = scale;

--- a/Images-Core/src/main/java/com/andavin/images/command/CreateCommand.java
+++ b/Images-Core/src/main/java/com/andavin/images/command/CreateCommand.java
@@ -272,7 +272,7 @@ final class CreateCommand extends BaseCommand implements Listener {
                     }
                     player.sendMessage(ChatColor.YELLOW + "Attempting to mint NFT..");
 
-                    CustomImage customImage = new CustomImage(player.getUniqueId(), task.contract, -1, task.tokenId,
+                    CustomImage customImage = new CustomImage(player.getUniqueId(), task.contract, task.tokenId,
                             task.nameSupplier.get(), location, direction, image);
 
                     for (CustomImageSection section : customImage.getSections()) {

--- a/Images-Core/src/main/java/com/andavin/images/data/SQLDataManager.java
+++ b/Images-Core/src/main/java/com/andavin/images/data/SQLDataManager.java
@@ -70,6 +70,8 @@ abstract class SQLDataManager implements DataManager {
                     CustomImage image = toImage(result.getBytes("data"));
                     image.setId(result.getInt("id"));
                     images.add(image);
+                    if(image.updateTokenId())
+                        save(image);
                 }
             }
         } catch (SQLException e) {

--- a/Images-Core/src/main/java/com/andavin/images/legacy/LegacyImportManager.java
+++ b/Images-Core/src/main/java/com/andavin/images/legacy/LegacyImportManager.java
@@ -39,6 +39,7 @@ import org.bukkit.entity.ItemFrame;
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -115,7 +116,7 @@ public final class LegacyImportManager {
 
                 Logger.info("Importing legacy image {} facing {}...", file.getName(), direction);
                 try {
-                    CustomImage image = new CustomImage(file.getName(), "", -1, legacyImage.getLocation(),
+                    CustomImage image = new CustomImage(file.getName(), "", -1, BigInteger.valueOf(-1), legacyImage.getLocation(),
                             direction, ImageIO.read(file));
                     dataManager.save(image);
                     importedImages.add(image);

--- a/Images-Core/src/main/java/com/andavin/images/legacy/LegacyImportManager.java
+++ b/Images-Core/src/main/java/com/andavin/images/legacy/LegacyImportManager.java
@@ -116,7 +116,7 @@ public final class LegacyImportManager {
 
                 Logger.info("Importing legacy image {} facing {}...", file.getName(), direction);
                 try {
-                    CustomImage image = new CustomImage(file.getName(), "", -1, BigInteger.valueOf(-1), legacyImage.getLocation(),
+                    CustomImage image = new CustomImage(file.getName(), "", BigInteger.valueOf(-1), legacyImage.getLocation(),
                             direction, ImageIO.read(file));
                     dataManager.save(image);
                     importedImages.add(image);

--- a/Images-v1_18_R1/pom.xml
+++ b/Images-v1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/Images-v1_18_R2/pom.xml
+++ b/Images-v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>images-parent</artifactId>
         <groupId>com.andavin</groupId>
-        <version>2.2.5</version>
+        <version>2.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.andavin</groupId>
     <artifactId>images-parent</artifactId>
-    <version>2.2.5</version>
+    <version>2.2.6</version>
     <modules>
         <module>Images-Core</module>
         <module>Images-Common</module>


### PR DESCRIPTION
Token ID's are now BigIntegers so it supports longer token id's. Because of Java serialization you can not remove old fields or change it's datatype once already implemented, so instead we keep it and convert them to BigIntegers if there are any old nft's using integers. 